### PR TITLE
Allow optional query params object to Dozuki.guide.get

### DIFF
--- a/dozuki.js
+++ b/dozuki.js
@@ -3,10 +3,19 @@
    function Dozuki(url, http) {
       baseUrl = url + "/api/2.0/";
       this.guides = {
-         get: function(guideid, langid) {
+         get: function(guideid, langid, params) {
+            params = params || {};
             var url = baseUrl + "guides/" + guideid;
             if (langid) {
-               url += "?langid=" + langid;
+               params["langid"] = langid;
+            }
+
+            var paramString = Object.keys(params).map(function(key) {
+               return params[key] ? key + "=" + params[key] : key;
+            }).join("&");
+
+            if (paramString) {
+               url += "?" + paramString;
             }
 
             return http.send(
@@ -19,8 +28,8 @@
                   }
                });
          }
-      }
-   }
+      };
+   };
 
    global.Dozuki.http = {};
 })(typeof window != 'undefined' ? window : module.exports);

--- a/dozuki.js
+++ b/dozuki.js
@@ -10,14 +10,6 @@
                params["langid"] = langid;
             }
 
-            var paramString = Object.keys(params).map(function(key) {
-               return params[key] ? key + "=" + params[key] : key;
-            }).join("&");
-
-            if (paramString) {
-               url += "?" + paramString;
-            }
-
             return http.send(
                url,
                {
@@ -25,7 +17,8 @@
                   method: 'get',
                   headers: {
                      'X-ALLOW-HTTP': 1
-                  }
+                  },
+                  params: params
                });
          }
       };

--- a/wrappers/jquery.http.js
+++ b/wrappers/jquery.http.js
@@ -5,8 +5,10 @@ Dozuki.http.jquery = function(jQuery) {
          headers:    options.headers,
          dataType:   'json',
          type:       options.method
-      }
+      };
+      var params = jQuery.param(options.params);
+
       // Already returns a promise object
-      return jQuery.ajax(url,  jQueryOptions);
+      return jQuery.ajax(url + params,  jQueryOptions);
    };
 };

--- a/wrappers/jquery.http.js
+++ b/wrappers/jquery.http.js
@@ -9,6 +9,6 @@ Dozuki.http.jquery = function(jQuery) {
       var params = jQuery.param(options.params);
 
       // Already returns a promise object
-      return jQuery.ajax(url + params,  jQueryOptions);
+      return jQuery.ajax(url + "?" + params,  jQueryOptions);
    };
 };


### PR DESCRIPTION
The Guide GET API endpoint allows more query parameters than just a
langid. This adds an optional `params` object to the get method, which
are added to the options object which is passed to the http wrapper.

This also extends the jQuery http wrapper to build and append a query
string to the given url using jQuery.param().