### PR TITLE
Add `headers` param to Dozuki.get

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ dozuki.guides.get(1234).then(function(guide) {
 ### Dozuki.guides
 An object exposing methods on the guide collection.
 
-#### Dozuki.guides.get(guideid)
+#### Dozuki.guides.get(guideid, [langid, params, headers])
 return a promise that will be fulfilled with a [JSON object directly from the
 API](https://www.ifixit.com/api/2.0/doc/Guides#get-a-guide)
 
@@ -29,7 +29,7 @@ A mock module (`Dozuki.http.mock`) and a jQuery module (`Dozuki.http.mock`) are
 provided to give Dozuki a way to make requests. It's pretty trivial make a new
 module for any given HTTP library.
 
-An http module only needs to have one method, `send(url, options)` 
+An http module only needs to have one method, `send(url, options)`
 the `options` object must support these attributes.
 
     data:       Object containing key:value mappings to send with the request
@@ -38,3 +38,9 @@ the `options` object must support these attributes.
     method:     HTTP Method to use for the request: get, post, patch, ...
 
 
+## Building & Running Tests
+
+```
+npm install
+npm test
+```

--- a/dozuki.js
+++ b/dozuki.js
@@ -3,11 +3,16 @@
    function Dozuki(url, http) {
       baseUrl = url + "/api/2.0/";
       this.guides = {
-         get: function(guideid, langid, params) {
+         get: function(guideid, langid, params, headers) {
+            headers = headers || {};
             params = params || {};
             var url = baseUrl + "guides/" + guideid;
             if (langid) {
                params["langid"] = langid;
+            }
+
+            if (!('X-ALLOW-HTTP' in headers)) {
+               headers['X-ALLOW-HTTP'] = 1;
             }
 
             return http.send(
@@ -15,9 +20,7 @@
                {
                   dataType:   'json',
                   method: 'get',
-                  headers: {
-                     'X-ALLOW-HTTP': 1
-                  },
+                  headers: headers,
                   params: params
                });
          }

--- a/dozuki.js
+++ b/dozuki.js
@@ -1,10 +1,10 @@
 (function (global) {
    global.Dozuki =
-   function Dozuki(url, http) {
+   function Dozuki(url, http, headers) {
+      headers = headers || {};
       baseUrl = url + "/api/2.0/";
       this.guides = {
-         get: function(guideid, langid, params, headers) {
-            headers = headers || {};
+         get: function(guideid, langid, params) {
             params = params || {};
             var url = baseUrl + "guides/" + guideid;
             if (langid) {

--- a/test.js
+++ b/test.js
@@ -8,7 +8,10 @@ var domain = "https://www.test.com";
 
 describe('Dozuki', function(){
    function newDozuki(httpMock) {
-      return new Dozuki(domain, httpMock)
+      return new Dozuki(domain, httpMock, {
+         'X-App-Id': 'ABCD123',
+         'X-ALLOW-HTTP': 0
+      })
    }
    describe('guides', function() {
       describe('get', function() {
@@ -28,26 +31,7 @@ describe('Dozuki', function(){
 
          it("should set the correct request options", function() {
             var http = Dozuki.http.mock("123");
-            newDozuki(http).guides.get(123, 'en', {}, {
-               'X-App-Id': 'ABCD123'
-            });
-
-            assert.deepEqual(http.sent.options, {
-               dataType:   'json',
-               method:     'get',
-               headers:    {
-                  'X-App-Id': 'ABCD123',
-                  'X-ALLOW-HTTP': 1
-               },
-               params:     {
-                  'langid': 'en'
-               }
-            });
-
-            newDozuki(http).guides.get(123, 'de', {}, {
-               'X-App-Id': 'ABCD123',
-               'X-ALLOW-HTTP': 0
-            });
+            newDozuki(http).guides.get(123, 'en');
 
             assert.deepEqual(http.sent.options, {
                dataType:   'json',
@@ -57,7 +41,7 @@ describe('Dozuki', function(){
                   'X-ALLOW-HTTP': 0
                },
                params:     {
-                  'langid': 'de'
+                  'langid': 'en'
                }
             });
 

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ Dozuki.http = {
    mock: require('./wrappers/mock.http.js').mock
 };
 
-var domain = "www.test.com";
+var domain = "https://www.test.com";
 
 describe('Dozuki', function(){
    function newDozuki(httpMock) {
@@ -18,7 +18,7 @@ describe('Dozuki', function(){
             var promise = d.guides.get(123);
 
             assert(promise.then);
-            assert.equal(http.sent.url, "https://" + domain + "/api/2.0/guides/123");
+            assert.equal(http.sent.url, domain + "/api/2.0/guides/123");
 
             promise.then(function(data) {
                assert.equal("123", data);
@@ -28,14 +28,23 @@ describe('Dozuki', function(){
 
          it("should set the correct request options", function() {
             var http = Dozuki.http.mock("123");
-            newDozuki(http).guides.get(123);
+            newDozuki(http).guides.get(123, 'en', {}, {
+               'X-App-Id': 'ABCD123'
+            });
 
             assert.deepEqual(http.sent.options, {
                dataType:   'json',
-               method:     'get'
+               method:     'get',
+               headers:    {
+                  'X-App-Id': 'ABCD123',
+                  'X-ALLOW-HTTP': 1
+               },
+               params:     {
+                  'langid': 'en'
+               }
             });
 
-            assert.equal(http.sent.url, "https://" + domain + "/api/2.0/guides/123");
+            assert.equal(http.sent.url, domain + "/api/2.0/guides/123");
          });
       });
    });

--- a/test.js
+++ b/test.js
@@ -44,6 +44,23 @@ describe('Dozuki', function(){
                }
             });
 
+            newDozuki(http).guides.get(123, 'de', {}, {
+               'X-App-Id': 'ABCD123',
+               'X-ALLOW-HTTP': 0
+            });
+
+            assert.deepEqual(http.sent.options, {
+               dataType:   'json',
+               method:     'get',
+               headers:    {
+                  'X-App-Id': 'ABCD123',
+                  'X-ALLOW-HTTP': 0
+               },
+               params:     {
+                  'langid': 'de'
+               }
+            });
+
             assert.equal(http.sent.url, domain + "/api/2.0/guides/123");
          });
       });


### PR DESCRIPTION
If you need to make authenticated requests, you need to be able to pass along some custom headers.

One use case is using API tokens on a private site to get a guide. 

This adds that functionality and updates the tests to actually work, and to test this new feature.